### PR TITLE
Feature: Integrate Firebase App Distribution & Crashlytics

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,6 +37,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Decode google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES }}" | base64 --decode > app/google-services.json
+
       - name: Run lint verification
         run: ./gradlew lintDebug
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ render.experimental.xml
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
+weather-service-account.json
 
 # Android Profiling
 *.hprof

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     jacoco
     alias(libs.plugins.sonar)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
+    alias(libs.plugins.firebase.appdistribution)
 }
 
 android {
@@ -30,6 +33,12 @@ android {
         }
         debug {
             enableUnitTestCoverage = true
+            firebaseAppDistribution {
+                artifactType = "APK"
+                groups = "internal-testers"
+                serviceCredentialsFile = "${project.rootDir}/app/weather-service-account.json"
+            }
+
         }
     }
     kotlin {
@@ -67,6 +76,9 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
     implementation(libs.bundles.retrofit)
     implementation(libs.logging.interceptor)
     implementation(libs.moshi.kotlin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,9 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.firebase.appdistribution) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,14 @@
 accompanistPermissions = "0.20.2"
 agp = "8.5.0"
 activityCompose = "1.9.0"
+appdistribution = "5.0.0"
 composeBom = "2024.06.00"
 coreKtx = "1.13.1"
 coreTesting = "2.2.0"
+crashlytics = "3.0.2"
 espressoCore = "3.6.1"
+firebaseBom = "33.1.1"
+gms = "4.4.2"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 koinBom = "3.5.6"
@@ -42,6 +46,9 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 koin-android = { module = "io.insert-koin:koin-android" }
 koin-android-test = { module = "io.insert-koin:koin-android-test" }
@@ -72,3 +79,6 @@ retrofit = ["converter-moshi", "retrofit"]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 sonar = { id = "org.sonarqube", version.ref = "sonar" }
+google-services = { id = "com.google.gms.google-services", version.ref = "gms" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }
+firebase-appdistribution = { id = "com.google.firebase.appdistribution", version.ref = "appdistribution" }


### PR DESCRIPTION
### Description

Adding crash reporting and app distribution

### Testing

Crash reporting
1. throw exception anywhere in the app
2. restart app
3. check Firebase dashboard crash report

App distribution
1. run in terminal `./gradlew assembleDebug appDistributionUploadDebug`
4. check Firebase dashboard distribution 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
