### PR TITLE
Add CD workflow

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -3,13 +3,11 @@ name: CD
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ] # for testing
 
   workflow_dispatch:
 
 jobs:
-  verify:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -1,8 +1,12 @@
-name: CI
+name: CD
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ] # for testing
+
+  workflow_dispatch:
 
 jobs:
   verify:
@@ -33,19 +37,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Decode google-services.json
+      - name: Decode service json files
         run: |
           echo "${{ secrets.GOOGLE_SERVICES }}" | base64 --decode > app/google-services.json
-
-      - name: Run lint verification
-        run: ./gradlew lintDebug
-
-      - name: Run debug unit tests
-        run: ./gradlew testDebugUnitTest
+          echo "${{ secrets.FIREBASE_APP_DISTRIBUTION }}" | base64 --decode > app/weather-service-account.json
 
       - name: Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew codeCoverage sonar
+        run: ./gradlew sonar
 
+      - name: Upload APK to Firebase App Distribution
+        run: ./gradlew assembleDebug appDistributionUploadDebug


### PR DESCRIPTION
### Description

Clear sepation between verifying integration vs deployment steps. This change keeps the verification step in the `continuos_integration.yml` file, while now introducing the `continous_deployment.yml` workflow for keeping Sonar up to date on main branch and distributing the app to Firebase once a PR is merged. This leads to easier app releases in future tester access.

### Testing

🤷

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
